### PR TITLE
fix: Exit if disconnected from wayland server

### DIFF
--- a/main.c
+++ b/main.c
@@ -287,10 +287,9 @@ int main(int argc, char *argv[])
             } else if (i == 1) {
                 timer_event();
             } else if (i == 2) {
-                if (fds[i].revents & (POLLERR | POLLHUP)) {
+                if (wl_display_dispatch(wl_display) == -1) {
                     goto quit;
                 }
-                wl_display_dispatch(wl_display);
             } else {
                 device_event(i);
             }

--- a/main.c
+++ b/main.c
@@ -287,12 +287,17 @@ int main(int argc, char *argv[])
             } else if (i == 1) {
                 timer_event();
             } else if (i == 2) {
+                if (fds[i].revents & (POLLERR | POLLHUP)) {
+                    goto quit;
+                }
                 wl_display_dispatch(wl_display);
             } else {
                 device_event(i);
             }
         }
     }
+quit:
+    wl_display_disconnect(wl_display);
 
     return 0;
 }


### PR DESCRIPTION
I use sway and had put `exec wljoywake` in my sway config to run the program in the background when the wm launches. I noticed after doing some testing involving repeatedly starting/stopping sway that I had many instances of wljoywake still running, and each using very high CPU.

Turns out they were in a tight loop where the call to poll() on the wayland display fd, which had since been closed by the server when the wm shut down, was returning almost immediately.

With this patch, we just exit when the fd is closed by the server. I also added a call to `wl_display_disconnect` to handle quitting the program when still connected, and make sure resources are freed.

Thanks for the program! It is very useful.